### PR TITLE
Correctly handle no external dependencies

### DIFF
--- a/lib/puppet-deptool/parser.rb
+++ b/lib/puppet-deptool/parser.rb
@@ -224,6 +224,14 @@ module PuppetDeptool
     end
 
     def update_fixtures
+      if @dependencies.nil? || @dependencies.empty?
+        info 'No external dependencies'
+        if File.exist?('.fixtures.yml')
+          info 'Removing existing .fixtures.yml file'
+          File.unlink('.fixtures.yml')
+        end
+        return
+      end
       flags = if Logger.level > 2
                 ['--debug']
               else


### PR DESCRIPTION
Modules with no external dependencies currently end up with all environment modules added as fixtures. This correctly handles that situation and also removes any existing fixtures file.