### PR TITLE
Correctly handle create_resources use in puppetlabs-firewall

### DIFF
--- a/lib/puppet-deptool/parser.rb
+++ b/lib/puppet-deptool/parser.rb
@@ -956,6 +956,7 @@ module PuppetDeptool
                 raise "Unknown create_resources/ensure_resource argument #{resource_type.class}" unless [
                   Puppet::Pops::Model::AccessExpression,
                   Puppet::Pops::Model::ConcatenatedString,
+                  Puppet::Pops::Model::VariableExpression,
                 ].include? resource_type.class
               end
             end


### PR DESCRIPTION
Fixes an error when scanning the newest puppetlabs-firewall module